### PR TITLE
.github: Run on gtk container instead of installing deps

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -10,13 +10,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    container: pksadiq/gtk:alpine-amd64
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
     - name: installdeps
-      run: sudo apt update && sudo apt install libgtk-4-dev
+      run: apk add make
     - name: make
       run: make
     - name: test


### PR DESCRIPTION
Currently the dependency install step takes 14 seconds of the 19 second build and test action. Hopefully using a docker image with dependencies pre-installed will be faster.